### PR TITLE
Fix for compiling CUDA with gcc >= 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ check_language(CUDA)
 
 if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
-    set(CMAKE_CUDA_STANDARD 11)
+    set(CMAKE_CUDA_STANDARD 14)
     file(GLOB CUDAfiles src/CUDA/*.cu)
 
     add_library(pypogpu SHARED ${CUDAfiles})


### PR DESCRIPTION
Update CUDA C++ standard to 14.

See a similar issue with `C++11` when compiling [PyTorch](https://github.com/NVIDIA/nccl/issues/1743).

Installs as expected using

`uv pip -v install "git+https://github.com/bdelwood/PyPO@1cd64a6abe96789e078e603b1ee241d6d15ecca9"` 

Tested with the Tutorial 1 notebook to confirm GPU-acceleration is working. 